### PR TITLE
Updated module to 1.0.3 to support kapacitor 0.13.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@ class kapacitor (
   $config_hipchat_state_changes_only = false,
   $ensure                            = 'installed',
   $install_from_repository           = false,
-  $version                           = '0.12.0-1',
+  $version                           = '0.13.1',
 ) {
 
   class { '::kapacitor::package': } ~>

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -24,7 +24,7 @@ class kapacitor::package {
           /386/   => "kapacitor_${::kapacitor::version}_i386.deb",
           default => "kapacitor_${::kapacitor::version}_amd64.deb",
         }
-        $package_source = "https://s3.amazonaws.com/kapacitor/${package_source_name}"
+        $package_source = "https://dl.influxdata.com/kapacitor/releases/${package_source_name}"
         wget::fetch { 'kapacitor':
           source      => $package_source,
           destination => "/tmp/${package_source_name}"
@@ -38,10 +38,10 @@ class kapacitor::package {
       }
       'redhat': {
         $package_source_name = $::architecture ? {
-          /386/   => "kapacitor-${::kapacitor::version}-1.i686.rpm",
-          default => "kapacitor-${::kapacitor::version}-1.x86_64.rpm",
+          /386/   => "kapacitor-${::kapacitor::version}.i386.rpm",
+          default => "kapacitor-${::kapacitor::version}.x86_64.rpm",
         }
-        $package_source = "http://get.influxdb.org/kapacitor/${package_source_name}"
+        $package_source = "https://dl.influxdata.com/kapacitor/releases/${package_source_name}"
         exec {
           'kapacitor_rpm':
             command => "rpm -ivh ${package_source}",

--- a/manifests/task/define.pp
+++ b/manifests/task/define.pp
@@ -38,7 +38,7 @@ define kapacitor::task::define(
 
     # Define the task:
     exec { "kapacitor-task-define-${name}":
-      command     => "/usr/bin/kapacitor define -name=${name} -type=${task_type} -tick=${tick_file} -dbrp=${influx_database}.${influx_retention}",
+      command     => "/usr/bin/kapacitor define ${name} -type=${task_type} -tick=${tick_file} -dbrp=${influx_database}.${influx_retention}",
       refreshonly => true,
       notify      => Exec["kapacitor-task-enable-${name}"]
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-kapacitor",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Chrusty",
   "summary": "Puppet module for Kapacitor",
   "license": "Apache-2.0",
@@ -20,5 +20,6 @@
   "requirements": [],
   "tags": [
     "kapacitor",
+    "influxdb"
   ]
 }

--- a/templates/kapacitor.conf.erb
+++ b/templates/kapacitor.conf.erb
@@ -291,11 +291,16 @@ data_dir = "<%= @config_data_dir %>"
     #
     # uncomment to enable
     #[udf.functions.pyavg]
-    #    prog = "/usr/bin/python2"
-    #    args = ["-u", "./udf/agent/examples/moving_avg.py"]
-    #    timeout = "10s"
+    #   prog = "/usr/bin/python2"
+    #   args = ["-u", "./udf/agent/examples/moving_avg.py"]
+    #   timeout = "10s"
     #   [udf.functions.pyavg.env]
     #       PYTHONPATH = "./udf/agent/py"
+
+    # Example UDF over a socket
+    #[udf.functions.myCustomUDF]
+    #   socket = "/path/to/socket"
+    #   timeout = "10s"
 
 [talk]
   # Configure Talk.


### PR DESCRIPTION
- version bump to 1.0.3
- updated default kapacitor version to 0.13.1 (including template updates)
- updated metadata.json
- updated used download urls for redhat and debian
- updated exec for tasks where the "-name=" part is deprecated and the task name is defined as is

Tested with Debian Jessie 8.5 and Puppet 4.5.2 successfully! (Should also work with older Debians)

fixes #1 
