### PR TITLE
http_log-enabled config option

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class kapacitor::config(
   $config_data_dir                   = $::kapacitor::config_data_dir,
   $config_hostname                   = $::kapacitor::config_hostname,
   $config_http_bind_address          = $::kapacitor::config_http_bind_address,
+  $config_http_log_enabled           = $::kapacitor::config_http_log_enabled,
   $config_influxdb_name              = $::kapacitor::config_influxdb_name,
   $config_influxdb_password          = $::kapacitor::config_influxdb_password,
   $config_influxdb_urls              = $::kapacitor::config_influxdb_urls,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class kapacitor (
   $config_data_dir                   = '/var/lib/kapacitor',
   $config_hostname                   = 'localhost',
   $config_http_bind_address          = ':9092',
+  $config_http_log_enabled           = true,
   $config_influxdb_name              = 'localhost',
   $config_influxdb_password          = '',
   $config_influxdb_urls              = ['http://localhost:8086'],

--- a/templates/kapacitor.conf.erb
+++ b/templates/kapacitor.conf.erb
@@ -12,7 +12,7 @@ data_dir = "<%= @config_data_dir %>"
   # Kapacitor calls.
   bind-address = "<%= @config_http_bind_address %>"
   auth-enabled = false
-  log-enabled = true
+  log-enabled = "<%= @config_http_log_enabled %>"
   write-tracing = false
   pprof-enabled = false
   https-enabled = false
@@ -335,3 +335,4 @@ data_dir = "<%= @config_data_dir %>"
   batch-size = 1000
   batch-pending = 5
   batch-timeout = "1s"
+


### PR DESCRIPTION
HTTP logs getting dumped into /var/log/kapacitor.log makes it quite difficult to troubleshoot, so I figured it's best to have it as a configurable option.

Doc:
https://github.com/influxdata/kapacitor/blob/master/etc/kapacitor/kapacitor.conf#L24